### PR TITLE
変換終了時の処理を修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
         cout << "\nError occurred while exporting the scene..." << endl;
 
     // Cleanup
-    lExporter->Destroy();
+    vmdfile.close();
     lSdkManager->Destroy();
 
     return 0;


### PR DESCRIPTION
pre-release後の変更。

- `ifstream`オブジェクトの close 忘れの修正
- FBX 関連のオブジェクトのメモリ解放処理を `FbxManager::Destroy()` に集約