### PR TITLE
#9 Exporter初期化成功後に出力が失敗する問題の修正

### DIFF
--- a/src/ConvertEncoding.h
+++ b/src/ConvertEncoding.h
@@ -3,11 +3,18 @@
 
 #ifdef _WIN32
 #include <fbxsdk.h>
+#include <Windows.h>
 #else
 #include <iconv.h>
 #endif
 
 #ifdef _WIN32
+
+bool IsShiftJISEnvironment()
+{
+    return GetConsoleCP() == 932; // 932 = Shift_JIS
+}
+
 std::string sjis_to_utf8(const std::string &input)
 {
     std::string name_converted;
@@ -24,6 +31,11 @@ std::string sjis_to_utf8(const std::string &input)
 }
 
 #else
+
+bool IsShiftJISEnvironment()
+{
+    return false;
+}
 
 std::string sjis_to_utf8(const std::string &input)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
     else
     {
         cerr << "Initializing the exporter failed..." << endl;
+        cout << lExporter->GetStatus().GetErrorString() << endl;
         vmdfile.close();
         lSdkManager->Destroy();
         return -1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,10 +60,7 @@ int main(int argc, char *argv[])
     bool exporter_prepared = lExporter->Initialize(outputfbxpathStr.c_str(), -1, IOSettings);
 
     if (exporter_prepared)
-    {
         cout << "The exporter successfully initialized." << endl;
-        cout << lExporter->GetStatus().GetCode() << endl;
-    }
     else
     {
         cerr << "Initializing the exporter failed..." << endl;
@@ -143,25 +140,11 @@ int main(int argc, char *argv[])
 
 void DebugConverting(uint32_t frame_no, string name_processing, unordered_map<string, string> shape_rename_map)
 {
-    for (const auto &name : shape_rename_map)
-    {
-        string name_old = name.first;
-        string name_new = name.second;
+    string key = IsShiftJISEnvironment() ? name_processing : sjis_to_utf8(name_processing);
 
-        // 現在キー登録中の名前が変換前後のマップに含まれていれば、その対応を出力する
-        if (IsShiftJISEnvironment())
-        {
-            if (name_processing == name_old)
-            {
-                cout << frame_no << " " << name_processing << " -> " << name_new << endl;
-            }
-        }
-        else
-        {
-            if (sjis_to_utf8(name_processing) == name_old)
-            {
-                cout << frame_no << " " << sjis_to_utf8(name_processing) << " -> " << name_new << endl;
-            }
-        }
+    unordered_map<string, string>::const_iterator it = shape_rename_map.find(key);
+    if (it != shape_rename_map.end())
+    {
+        cout << frame_no << " " << key << " -> " << it->second << endl;
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,19 @@ int main(int argc, char *argv[])
 
     bool exporter_prepared = lExporter->Initialize(outputfbxpathStr.c_str(), -1, IOSettings);
 
+    if (exporter_prepared)
+    {
+        cout << "The exporter successfully initialized." << endl;
+        cout << lExporter->GetStatus().GetCode() << endl;
+    }
+    else
+    {
+        cerr << "Initializing the exporter failed..." << endl;
+        vmdfile.close();
+        lSdkManager->Destroy();
+        return -1;
+    }
+
     // FbxAnimStack と FbxAnimationLayer の作成
     FbxAnimStack *lAnimStack = FbxAnimStack::Create(lScene, "Take_VMDshapeAnimation");
     FbxAnimLayer *lAnimLayer = FbxAnimLayer::Create(lScene, "BaseAnimation");
@@ -116,7 +129,10 @@ int main(int argc, char *argv[])
     if (lExporter->Export(lScene))
         cout << "\nProgram Success!" << endl;
     else
+    {
         cout << "\nError occurred while exporting the scene..." << endl;
+        cout << lExporter->GetStatus().GetErrorString() << endl;
+    }
 
     // Cleanup
     vmdfile.close();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,8 +118,8 @@ int main(int argc, char *argv[])
     // 名称変更前後のマップ（引数の指定から作成）を元に、既存のシェイプキー名を変更
     for (const auto &map : shape_rename_map)
     {
-        std::string name_old = IsShiftJISEnvironment() ? sjis_to_utf8(map.first) : map.first;
-        std::string name_new = map.second;
+        string name_old = IsShiftJISEnvironment() ? sjis_to_utf8(map.first) : map.first;
+        string name_new = map.second;
         UpdateShapekeyName(lMesh, name_old, name_new);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,6 +143,7 @@ void DebugConverting(uint32_t frame_no, string name_processing, unordered_map<st
 {
     string key = IsShiftJISEnvironment() ? name_processing : sjis_to_utf8(name_processing);
 
+    // 現在キー登録中の名前が変換前後のマップに含まれていれば、その対応を出力する
     unordered_map<string, string>::const_iterator it = shape_rename_map.find(key);
     if (it != shape_rename_map.end())
     {


### PR DESCRIPTION
- 出力パスのエンコーディング変換
- Windows のターミナル入力がUTF-8またShift-JISのどちらの場合にも対応
- エラー時のデバッグの強化